### PR TITLE
Update ja language

### DIFF
--- a/src/main/resources/ja.yml
+++ b/src/main/resources/ja.yml
@@ -15,10 +15,10 @@ ENABLE: 有効にする
 DISABLE: 無効にする
 ENABLED: 有効
 DISABLED: 無効
-SHUFFLE_MODE: シャッフル再生
-LOOP_MODE: ループモード
-CONNEXION_MUSIC: サーバー接続時の再生
-PARTICLES: パーティクル
+SHUFFLE_MODE: 'シャッフル再生を{TOGGLE}'
+LOOP_MODE: 'ループモードを{TOGGLE}'
+CONNEXION_MUSIC: 'サーバー接続時の再生を{TOGGLE}'
+PARTICLES: 'パーティクルを{TOGGLE}'
 MUSIC_PLAYING: '§a再生中の曲名:'
 INCORRECT_SYNTAX: §c構文が正しくありません。
 RELOAD_LAUNCH: §aリロード中です

--- a/src/main/resources/ja.yml
+++ b/src/main/resources/ja.yml
@@ -11,8 +11,8 @@ LEFT_CLICK: '§e左クリック: 音量を10%上げる'
 RANDOM_MUSIC: §3ランダム再生
 STOP: §c音楽停止
 MUSIC_STOPPED: §a音楽を停止しました。
-ENABLE: '[有効]'
-DISABLE: '[無効]'
+ENABLE: 有効にする
+DISABLE: 無効にする
 ENABLED: 有効
 DISABLED: 無効
 SHUFFLE_MODE: シャッフル再生


### PR DESCRIPTION
ENABLE and DISABLE cannot be translated into Japanese.
For example "有効にする　パーティクル" is not the way we usually say it.
There is also the word 有効化, but that can be taken to mean the opposite.