### PR TITLE
POM fixup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,16 @@
 
 	<repositories>
 		<repository>
+			<id>spigot-repo</id>
+			<url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+		</repository>
+		<repository>
+			<id>minecraft-repo</id>
+			<url>https://libraries.minecraft.net</url>
+		</repository>
+		<repository>
 			<id>placeholderapi</id>
-			<url>http://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+			<url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
 		</repository>
 		<repository>
 			<id>jitpack.io</id>
@@ -30,7 +38,7 @@
 		<dependency>
 			<groupId>me.clip</groupId>
 			<artifactId>placeholderapi</artifactId>
-			<version>2.10.11</version>
+			<version>2.11.1</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -41,8 +49,14 @@
 		</dependency>
 		<dependency>
 			<groupId>org.spigotmc</groupId>
-			<artifactId>spigot</artifactId>
+			<artifactId>spigot-api</artifactId>
 			<version>1.18.1-R0.1-SNAPSHOT</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.mojang</groupId>
+			<artifactId>authlib</artifactId>
+			<version>1.5.21</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
 		<dependency>
 			<groupId>com.mojang</groupId>
 			<artifactId>authlib</artifactId>
-			<version>1.5.21</version>
+			<version>1.5.26</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -13,11 +13,11 @@
 
 	<repositories>
 		<repository>
-			<id>spigot-repo</id>
+			<id>spigotmc-repo</id>
 			<url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
 		</repository>
 		<repository>
-			<id>minecraft-repo</id>
+			<id>minecraft-libraries</id>
 			<url>https://libraries.minecraft.net</url>
 		</repository>
 		<repository>
@@ -87,7 +87,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.1.0</version>
+				<version>3.2.4</version>
 				<configuration>
 					<relocations>
 						<relocation>


### PR DESCRIPTION
Previously, I was not able to compile the plugin in a clean environment.

- Updated clip's repo from `http` to `https`. 
  - Maven no longer supports unsecure `http` repositories.
- Updated PAPI dependency
- Added Spigot's repo
- Added Mojang's repo for authlib
  - Added authlib dependency